### PR TITLE
Text prompt: configurable suffix and cursor/word/line editing

### DIFF
--- a/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
+++ b/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
@@ -91,6 +91,9 @@ type
     FClearOnFinish           : Boolean;
     FRenderedLineCount       : Integer;
     procedure DrawPromptLine(const console : IAnsiConsole);
+    procedure RedrawInput(const console : IAnsiConsole; const value : string; const caret : Integer; const shrunk : Boolean);
+    function  PrevWordStart(const value : string; const caret : Integer) : Integer;
+    function  NextWordStart(const value : string; const caret : Integer) : Integer;
     function  IsValidChoice(const value : string) : Boolean;
   public
     constructor Create;
@@ -162,6 +165,18 @@ begin
   if s = '' then Exit;
   SetLength(segs, 1);
   segs[0] := TAnsiSegment.Text(s, style);
+  console.Write(segs);
+end;
+
+{ Emit a raw control sequence (cursor move / erase) through the normal write
+  path so it stays serialised with the rest of the output. }
+procedure EmitControl(const console : IAnsiConsole; const s : string);
+var
+  segs : TAnsiSegments;
+begin
+  if s = '' then Exit;
+  SetLength(segs, 1);
+  segs[0] := TAnsiSegment.ControlCode(s);
   console.Write(segs);
 end;
 
@@ -333,9 +348,66 @@ begin
   EmitPlain(console, FPromptSuffix);
 end;
 
+// Repaint the prompt and current input in place and park the cursor at caret.
+// CR (no erase-line) overwrites cells rather than blanking them, which avoids
+// flicker; on a shrink a single trailing space wipes the vacated cell.
+procedure TTextPrompt.RedrawInput(const console : IAnsiConsole; const value : string; const caret : Integer; const shrunk : Boolean);
+var
+  shown : string;
+  back  : Integer;
+begin
+  EmitControl(console, #13);
+  DrawPromptLine(console);
+  if FSecret then
+    shown := StringOfChar(FMask, Length(value))
+  else
+    shown := value;
+  EmitPlain(console, shown);
+  back := Length(shown) - caret;
+  if shrunk then
+  begin
+    EmitPlain(console, ' ');
+    Inc(back);
+  end;
+  if back > 0 then
+    EmitControl(console, ESC + '[' + IntToStr(back) + 'D');
+end;
+
+// Caret position at the start of the word to the left (skips spaces, then the
+// word). caret is the number of characters before the cursor; value is 1-based.
+function TTextPrompt.PrevWordStart(const value : string; const caret : Integer) : Integer;
+var
+  i : Integer;
+begin
+  i := caret;
+  while (i > 0) and (value[i] = ' ') do
+    Dec(i);
+  while (i > 0) and (value[i] <> ' ') do
+    Dec(i);
+  result := i;
+end;
+
+// Caret position at the start of the next word to the right (skips the rest of
+// the current word, then spaces).
+function TTextPrompt.NextWordStart(const value : string; const caret : Integer) : Integer;
+var
+  i, len : Integer;
+begin
+  len := Length(value);
+  i := caret;
+  while (i < len) and (value[i + 1] <> ' ') do
+    Inc(i);
+  while (i < len) and (value[i + 1] = ' ') do
+    Inc(i);
+  result := i;
+end;
+
 function TTextPrompt.Show(const console : IAnsiConsole) : string;
 var
   buffer : string;
+  caret  : Integer;
+  target : Integer;
+  ctrl   : Boolean;
   key    : TConsoleKeyInfo;
   ch     : Char;
   vr     : TPromptValidationResult;
@@ -358,12 +430,14 @@ begin
   while not committed do
   begin
     buffer := '';
+    caret := 0;
     DrawPromptLine(console);
     Inc(FRenderedLineCount);
 
     while True do
     begin
       key := console.Input.ReadKey(True);
+      ctrl := TConsoleModifier.Control in key.Modifiers;
       case key.Key of
         TConsoleKey.Enter:
         begin
@@ -413,24 +487,74 @@ begin
           // No default -> ignore Escape
         end;
 
-        TConsoleKey.Backspace:
-        begin
-          if Length(buffer) > 0 then
+        TConsoleKey.LeftArrow:
+          if ctrl then
           begin
-            SetLength(buffer, Length(buffer) - 1);
-            EmitPlain(console, #8 + ' ' + #8);
+            target := PrevWordStart(buffer, caret);
+            if target < caret then
+            begin
+              EmitControl(console, ESC + '[' + IntToStr(caret - target) + 'D');
+              caret := target;
+            end;
+          end
+          else if caret > 0 then
+          begin
+            Dec(caret);
+            EmitControl(console, ESC + '[1D');
           end;
-        end;
+
+        TConsoleKey.RightArrow:
+          if ctrl then
+          begin
+            target := NextWordStart(buffer, caret);
+            if target > caret then
+            begin
+              EmitControl(console, ESC + '[' + IntToStr(target - caret) + 'C');
+              caret := target;
+            end;
+          end
+          else if caret < Length(buffer) then
+          begin
+            Inc(caret);
+            EmitControl(console, ESC + '[1C');
+          end;
+
+        TConsoleKey.Home:
+          if caret > 0 then
+          begin
+            EmitControl(console, ESC + '[' + IntToStr(caret) + 'D');
+            caret := 0;
+          end;
+
+        TConsoleKey.&End:
+          if caret < Length(buffer) then
+          begin
+            EmitControl(console, ESC + '[' + IntToStr(Length(buffer) - caret) + 'C');
+            caret := Length(buffer);
+          end;
+
+        TConsoleKey.Backspace:
+          if caret > 0 then
+          begin
+            Delete(buffer, caret, 1);
+            Dec(caret);
+            RedrawInput(console, buffer, caret, True);
+          end;
+
+        TConsoleKey.Delete:
+          if caret < Length(buffer) then
+          begin
+            Delete(buffer, caret + 1, 1);
+            RedrawInput(console, buffer, caret, True);
+          end;
 
       else
         ch := key.KeyChar;
         if (ch >= #32) and (ch <> #127) then
         begin
-          buffer := buffer + ch;
-          if FSecret then
-            EmitPlain(console, FMask)
-          else
-            EmitPlain(console, ch);
+          Insert(ch, buffer, caret + 1);
+          Inc(caret);
+          RedrawInput(console, buffer, caret, False);
         end;
       end;
     end;

--- a/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
+++ b/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
@@ -91,7 +91,9 @@ type
     FClearOnFinish           : Boolean;
     FRenderedLineCount       : Integer;
     procedure DrawPromptLine(const console : IAnsiConsole);
-    procedure RedrawInput(const console : IAnsiConsole; const value : string; const caret : Integer; const shrunk : Boolean);
+    function  PromptWidth : Integer;
+    function  Displayed(const value : string) : string;
+    procedure MoveCaret(const console : IAnsiConsole; const fromCell, toCell : Integer; const fromPending : Boolean = False);
     function  PrevWordStart(const value : string; const caret : Integer) : Integer;
     function  NextWordStart(const value : string; const caret : Integer) : Integer;
     function  IsValidChoice(const value : string) : Boolean;
@@ -348,29 +350,81 @@ begin
   EmitPlain(console, FPromptSuffix);
 end;
 
-// Repaint the prompt and current input in place and park the cursor at caret.
-// CR (no erase-line) overwrites cells rather than blanking them, which avoids
-// flicker; on a shrink a single trailing space wipes the vacated cell.
-procedure TTextPrompt.RedrawInput(const console : IAnsiConsole; const value : string; const caret : Integer; const shrunk : Boolean);
+// Visible width of the prompt prefix (prompt markup + choices + default +
+// suffix). Used to map a caret offset to its wrapped (row, column) position.
+function TTextPrompt.PromptWidth : Integer;
 var
-  shown : string;
-  back  : Integer;
+  promptMarkup : IMarkup;
+  joined       : string;
+  i            : Integer;
 begin
-  EmitControl(console, #13);
-  DrawPromptLine(console);
-  if FSecret then
-    shown := StringOfChar(FMask, Length(value))
-  else
-    shown := value;
-  EmitPlain(console, shown);
-  back := Length(shown) - caret;
-  if shrunk then
+  result := 0;
+  if FPrompt <> '' then
   begin
-    EmitPlain(console, ' ');
-    Inc(back);
+    promptMarkup := Markup(FPrompt);
+    result := result + promptMarkup.Length;
   end;
-  if back > 0 then
-    EmitControl(console, ESC + '[' + IntToStr(back) + 'D');
+  if FShowChoices and (Length(FChoices) > 0) then
+  begin
+    joined := '';
+    for i := 0 to High(FChoices) do
+    begin
+      if i > 0 then joined := joined + '/';
+      joined := joined + FChoices[i];
+    end;
+    result := result + 3 + Length(joined);
+  end;
+  if FHasDefault and not FSecret and FShowDefaultValue then
+    result := result + 3 + Length(FDefault);
+  result := result + Length(FPromptSuffix);
+end;
+
+function TTextPrompt.Displayed(const value : string) : string;
+begin
+  if FSecret then
+    result := StringOfChar(FMask, Length(value))
+  else
+    result := value;
+end;
+
+// Move the terminal cursor between two positions in the input, given as
+// character offsets after the prompt. Both are mapped through the console
+// width so the move stays correct when the input wraps across rows.
+// fromPending marks that the cursor just printed up to fromCell: a terminal
+// with delayed end-of-line wrap then sits on the last column of the previous
+// row rather than column 0 of the next one, so that row is used as the origin.
+procedure TTextPrompt.MoveCaret(const console : IAnsiConsole; const fromCell, toCell : Integer; const fromPending : Boolean = False);
+var
+  width   : Integer;
+  prompt  : Integer;
+  fromAbs : Integer;
+  fromRow : Integer;
+  toRow   : Integer;
+  toCol   : Integer;
+  seq     : string;
+begin
+  if fromCell = toCell then
+    Exit;
+  width := console.Profile.Width;
+  if width < 1 then
+    width := 1;
+  prompt := PromptWidth;
+  fromAbs := prompt + fromCell;
+  if fromPending and (fromAbs > 0) and (fromAbs mod width = 0) then
+    fromRow := fromAbs div width - 1
+  else
+    fromRow := fromAbs div width;
+  toRow := (prompt + toCell) div width;
+  toCol := (prompt + toCell) mod width;
+  seq := '';
+  if toRow < fromRow then
+    seq := seq + ESC + '[' + IntToStr(fromRow - toRow) + 'A'
+  else if toRow > fromRow then
+    seq := seq + ESC + '[' + IntToStr(toRow - fromRow) + 'B';
+  seq := seq + #13;
+  if toCol > 0 then
+    seq := seq + ESC + '[' + IntToStr(toCol) + 'C';
+  EmitControl(console, seq);
 end;
 
 // Caret position at the start of the word to the left (skips spaces, then the
@@ -407,6 +461,8 @@ var
   buffer : string;
   caret  : Integer;
   target : Integer;
+  width  : Integer;
+  tail   : string;
   ctrl   : Boolean;
   key    : TConsoleKeyInfo;
   ch     : Char;
@@ -488,64 +544,88 @@ begin
         end;
 
         TConsoleKey.LeftArrow:
-          if ctrl then
           begin
-            target := PrevWordStart(buffer, caret);
-            if target < caret then
-            begin
-              EmitControl(console, ESC + '[' + IntToStr(caret - target) + 'D');
-              caret := target;
-            end;
-          end
-          else if caret > 0 then
-          begin
-            Dec(caret);
-            EmitControl(console, ESC + '[1D');
+            if ctrl then
+              target := PrevWordStart(buffer, caret)
+            else if caret > 0 then
+              target := caret - 1
+            else
+              target := caret;
+            MoveCaret(console, caret, target);
+            caret := target;
           end;
 
         TConsoleKey.RightArrow:
-          if ctrl then
           begin
-            target := NextWordStart(buffer, caret);
-            if target > caret then
-            begin
-              EmitControl(console, ESC + '[' + IntToStr(target - caret) + 'C');
-              caret := target;
-            end;
-          end
-          else if caret < Length(buffer) then
-          begin
-            Inc(caret);
-            EmitControl(console, ESC + '[1C');
+            if ctrl then
+              target := NextWordStart(buffer, caret)
+            else if caret < Length(buffer) then
+              target := caret + 1
+            else
+              target := caret;
+            MoveCaret(console, caret, target);
+            caret := target;
           end;
 
         TConsoleKey.Home:
-          if caret > 0 then
           begin
-            EmitControl(console, ESC + '[' + IntToStr(caret) + 'D');
+            MoveCaret(console, caret, 0);
             caret := 0;
           end;
 
         TConsoleKey.&End:
-          if caret < Length(buffer) then
           begin
-            EmitControl(console, ESC + '[' + IntToStr(Length(buffer) - caret) + 'C');
+            MoveCaret(console, caret, Length(buffer));
             caret := Length(buffer);
+          end;
+
+        TConsoleKey.UpArrow:
+          begin
+            width := console.Profile.Width;
+            // Only when there is a row above (the input has wrapped).
+            if (width > 0) and ((PromptWidth + caret) >= width) then
+            begin
+              target := caret - width;
+              if target < 0 then
+                target := 0;
+              MoveCaret(console, caret, target);
+              caret := target;
+            end;
+          end;
+
+        TConsoleKey.DownArrow:
+          begin
+            width := console.Profile.Width;
+            // Only when there is a row below the caret.
+            if (width > 0) and
+               (((PromptWidth + caret) div width) < ((PromptWidth + Length(buffer)) div width)) then
+            begin
+              target := caret + width;
+              if target > Length(buffer) then
+                target := Length(buffer);
+              MoveCaret(console, caret, target);
+              caret := target;
+            end;
           end;
 
         TConsoleKey.Backspace:
           if caret > 0 then
           begin
             Delete(buffer, caret, 1);
+            MoveCaret(console, caret, caret - 1);
             Dec(caret);
-            RedrawInput(console, buffer, caret, True);
+            tail := Displayed(Copy(buffer, caret + 1, MaxInt));
+            EmitPlain(console, tail + ' ');
+            MoveCaret(console, Length(buffer) + 1, caret, True);
           end;
 
         TConsoleKey.Delete:
           if caret < Length(buffer) then
           begin
             Delete(buffer, caret + 1, 1);
-            RedrawInput(console, buffer, caret, True);
+            tail := Displayed(Copy(buffer, caret + 1, MaxInt));
+            EmitPlain(console, tail + ' ');
+            MoveCaret(console, Length(buffer) + 1, caret, True);
           end;
 
       else
@@ -553,8 +633,10 @@ begin
         if (ch >= #32) and (ch <> #127) then
         begin
           Insert(ch, buffer, caret + 1);
+          tail := Displayed(Copy(buffer, caret + 1, MaxInt));
+          EmitPlain(console, tail);
           Inc(caret);
-          RedrawInput(console, buffer, caret, False);
+          MoveCaret(console, Length(buffer), caret, True);
         end;
       end;
     end;

--- a/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
+++ b/source/Prompts/VSoft.AnsiConsole.Prompts.Text.pas
@@ -42,6 +42,10 @@ type
     function WithValidator(const validator : TTextPromptValidator) : ITextPrompt;
     function WithAllowEmpty(value : Boolean) : ITextPrompt;
 
+    { Separator emitted after the prompt (and choices/default), before the
+      typed input. Defaults to ': '. Pass '' to drop it entirely. }
+    function WithPromptSuffix(const value : string) : ITextPrompt;
+
     { Choice support. When at least one choice is added, the input is
       validated against the choice list before commit; non-matching input
       is rejected with FInvalidChoiceMessage. ShowChoices controls whether
@@ -68,6 +72,7 @@ type
   TTextPrompt = class(TInterfacedObject, ITextPrompt)
   strict private
     FPrompt              : string;
+    FPromptSuffix        : string;
     FDefault             : string;
     FHasDefault          : Boolean;
     FSecret              : Boolean;
@@ -95,6 +100,7 @@ type
     function WithSecret(mask : Char) : ITextPrompt; overload;
     function WithValidator(const validator : TTextPromptValidator) : ITextPrompt;
     function WithAllowEmpty(value : Boolean) : ITextPrompt;
+    function WithPromptSuffix(const value : string) : ITextPrompt;
     function WithChoice(const value : string) : ITextPrompt;
     function WithShowChoices(value : Boolean) : ITextPrompt;
     function WithShowDefaultValue(value : Boolean) : ITextPrompt;
@@ -165,6 +171,7 @@ constructor TTextPrompt.Create;
 begin
   inherited Create;
   FMask                  := '*';
+  FPromptSuffix          := ': ';
   FAllowEmpty            := True;
   FShowChoices           := True;
   FShowDefaultValue      := True;
@@ -213,6 +220,12 @@ end;
 function TTextPrompt.WithAllowEmpty(value : Boolean) : ITextPrompt;
 begin
   FAllowEmpty := value;
+  result := Self;
+end;
+
+function TTextPrompt.WithPromptSuffix(const value : string) : ITextPrompt;
+begin
+  FPromptSuffix := value;
   result := Self;
 end;
 
@@ -317,7 +330,7 @@ begin
     EmitStyled(console, FDefault, FDefaultValueStyle);
     EmitPlain(console, ')');
   end;
-  EmitPlain(console, ': ');
+  EmitPlain(console, FPromptSuffix);
 end;
 
 function TTextPrompt.Show(const console : IAnsiConsole) : string;

--- a/tests/Tests.Prompts.pas
+++ b/tests/Tests.Prompts.pas
@@ -30,6 +30,8 @@ type
     [Test] procedure Text_Enter_ReturnsTypedValue;
     [Test] procedure Text_EmptyEnter_ReturnsDefault;
     [Test] procedure Text_Backspace_PopsLastChar;
+    [Test] procedure Text_PromptSuffix_Custom_Replaces;
+    [Test] procedure Text_PromptSuffix_Empty_OmitsDefaultColon;
     [Test] procedure Text_ValidatorRejectsThenAccepts;
     [Test] procedure Text_Secret_MasksInOutput;
     [Test] procedure Text_Choices_RejectsNonMember;
@@ -136,6 +138,33 @@ begin
   input.Enqueue(TConsoleKey.Enter);
   value := TextPrompt.Show(console);
   Assert.AreEqual('abX', value);
+end;
+
+procedure TPromptTests.Text_PromptSuffix_Custom_Replaces;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('x');
+  input.Enqueue(TConsoleKey.Enter);
+  TextPrompt.WithPrompt('Name').WithPromptSuffix(' > ').Show(console);
+  Assert.IsTrue(Pos(' > ', captured.Text) > 0, 'Custom suffix should be emitted');
+  Assert.IsFalse(Pos('Name: ', captured.Text) > 0, 'Default colon suffix should not appear');
+end;
+
+procedure TPromptTests.Text_PromptSuffix_Empty_OmitsDefaultColon;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('x');
+  input.Enqueue(TConsoleKey.Enter);
+  TextPrompt.WithPrompt('Name').WithPromptSuffix('').Show(console);
+  Assert.IsFalse(Pos(': ', captured.Text) > 0, 'Empty suffix should omit the default '': ''');
 end;
 
 procedure TPromptTests.Text_ValidatorRejectsThenAccepts;

--- a/tests/Tests.Prompts.pas
+++ b/tests/Tests.Prompts.pas
@@ -32,6 +32,12 @@ type
     [Test] procedure Text_Backspace_PopsLastChar;
     [Test] procedure Text_PromptSuffix_Custom_Replaces;
     [Test] procedure Text_PromptSuffix_Empty_OmitsDefaultColon;
+    [Test] procedure Text_LeftArrow_Insert_InsertsMidLine;
+    [Test] procedure Text_Home_Insert_AtStart;
+    [Test] procedure Text_Backspace_MidLine_RemovesBeforeCaret;
+    [Test] procedure Text_Delete_RemovesAtCaret;
+    [Test] procedure Text_End_MovesBackToLineEnd;
+    [Test] procedure Text_CtrlLeft_JumpsToWordStart;
     [Test] procedure Text_ValidatorRejectsThenAccepts;
     [Test] procedure Text_Secret_MasksInOutput;
     [Test] procedure Text_Choices_RejectsNonMember;
@@ -165,6 +171,104 @@ begin
   input.Enqueue(TConsoleKey.Enter);
   TextPrompt.WithPrompt('Name').WithPromptSuffix('').Show(console);
   Assert.IsFalse(Pos(': ', captured.Text) > 0, 'Empty suffix should omit the default '': ''');
+end;
+
+procedure TPromptTests.Text_LeftArrow_Insert_InsertsMidLine;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('ac');
+  input.Enqueue(TConsoleKey.LeftArrow);
+  input.Enqueue('b');
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('abc', value);
+end;
+
+procedure TPromptTests.Text_Home_Insert_AtStart;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('bc');
+  input.Enqueue(TConsoleKey.Home);
+  input.Enqueue('a');
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('abc', value);
+end;
+
+procedure TPromptTests.Text_Backspace_MidLine_RemovesBeforeCaret;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('abc');
+  input.Enqueue(TConsoleKey.LeftArrow);
+  input.Enqueue(TConsoleKey.Backspace);
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('ac', value);
+end;
+
+procedure TPromptTests.Text_Delete_RemovesAtCaret;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('abc');
+  input.Enqueue(TConsoleKey.Home);
+  input.Enqueue(TConsoleKey.Delete);
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('bc', value);
+end;
+
+procedure TPromptTests.Text_End_MovesBackToLineEnd;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('ab');
+  input.Enqueue(TConsoleKey.Home);
+  input.Enqueue(TConsoleKey.&End);
+  input.Enqueue('c');
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('abc', value);
+end;
+
+procedure TPromptTests.Text_CtrlLeft_JumpsToWordStart;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  BuildScripted(console, input, captured);
+  input.Enqueue('foo bar');
+  // Ctrl+Left from the end jumps to the start of 'bar' (not one char left).
+  input.Enqueue(TConsoleKeyInfo.Create(#0, TConsoleKey.LeftArrow, False, False, True));
+  input.Enqueue('X');
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.Show(console);
+  Assert.AreEqual('foo Xbar', value);
 end;
 
 procedure TPromptTests.Text_ValidatorRejectsThenAccepts;

--- a/tests/Tests.Prompts.pas
+++ b/tests/Tests.Prompts.pas
@@ -38,6 +38,7 @@ type
     [Test] procedure Text_Delete_RemovesAtCaret;
     [Test] procedure Text_End_MovesBackToLineEnd;
     [Test] procedure Text_CtrlLeft_JumpsToWordStart;
+    [Test] procedure Text_UpArrow_MovesUpOneVisualRow;
     [Test] procedure Text_ValidatorRejectsThenAccepts;
     [Test] procedure Text_Secret_MasksInOutput;
     [Test] procedure Text_Choices_RejectsNonMember;
@@ -269,6 +270,24 @@ begin
   input.Enqueue(TConsoleKey.Enter);
   value := TextPrompt.Show(console);
   Assert.AreEqual('foo Xbar', value);
+end;
+
+procedure TPromptTests.Text_UpArrow_MovesUpOneVisualRow;
+var
+  console : IAnsiConsole;
+  input   : TScriptedConsoleInput;
+  captured : ICapturedAnsiOutput;
+  value   : string;
+begin
+  // Console width 80, empty suffix -> prompt width 0. After 85 chars the caret
+  // sits on row 1; UpArrow moves it back one row (80 chars) to offset 5.
+  BuildScripted(console, input, captured);
+  input.Enqueue(StringOfChar('a', 85));
+  input.Enqueue(TConsoleKey.UpArrow);
+  input.Enqueue('X');
+  input.Enqueue(TConsoleKey.Enter);
+  value := TextPrompt.WithPromptSuffix('').Show(console);
+  Assert.AreEqual(StringOfChar('a', 5) + 'X' + StringOfChar('a', 80), value);
 end;
 
 procedure TPromptTests.Text_ValidatorRejectsThenAccepts;


### PR DESCRIPTION
Enhances `TTextPrompt` (used by `AnsiConsole.Ask` / `AnsiConsole.TextPrompt`)
with editing and prompt-formatting options.

Changes:

1. The trailing `': '` after the prompt was
   hardcoded. `WithPromptSuffix(value)` (default `': '`) lets a caller change it
   or pass `''` to drop the separator entirely (e.g. a clean `> ` prompt).

2. The input loop was append-only (it ignored
   arrow keys). It now edits at the caret:
   - Left/Right, Home/End, Delete, Backspace and printable insert at the caret.
   - Ctrl+Left / Ctrl+Right jump by word.
   - Repaint happens in place (no full erase) to avoid flicker.

3. Caret movement is mapped through the console
   width, so Left/Right/Home/End/Up/Down and edits stay correct when the input
   wraps across rows. Repositioning after an edit accounts for the terminal's
   delayed end-of-line (pending) wrap.

Added 9 DUnitX fixtures driven by the existing scripted console input:
configurable/empty suffix, mid-line insert, Home insert, mid-line backspace,
Delete, End, Ctrl+Left word jump, and an Up-arrow row move.